### PR TITLE
Feat: CreateSpace 구현 (Create + Edit 하나로 통일)  

### DIFF
--- a/src/components/CreateSpaceModal/DeleteModal.jsx
+++ b/src/components/CreateSpaceModal/DeleteModal.jsx
@@ -1,0 +1,96 @@
+import Modal from "../Modal";
+import "./CreateModal.css";
+
+function DeleteModal({ isOpen, onClose, onConfirm, spaceName }) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      overlayStyle={{
+        alignItems: "flex-start",
+        justifyContent: "center",
+      }}
+      contentStyle={{
+        width: "380px",
+        maxWidth: "none",
+        minWidth: "auto",
+        top: "30vh",
+        position: "relative",
+      }}
+    >
+      <div
+        style={{
+          textAlign: "center",
+          fontFamily: "NotoSansKR-Bold, sans-serif",
+          fontWeight: 700,
+          fontSize: "1.2rem",
+          marginTop: 10,
+          marginBottom: 35,
+        }}
+      >
+        정말로 삭제하시겠습니까?
+      </div>
+
+      <div
+        style={{
+          textAlign: "center",
+          fontFamily: "'NotoSansKR-Regular', sans-serif",
+          marginBottom: 20,
+          fontSize: "1rem",
+          color: "#1a1a1a",
+        }}
+      >
+        <div>
+          <span style={{ color: "#8BE2B6" }}>
+            <strong>{spaceName}</strong>
+          </span>{" "}
+          공간에 포함된 <br />
+          모든 리스트도 함께 삭제됩니다.
+        </div>
+        <div
+          style={{
+            color: "#787878",
+            fontSize: "0.85rem",
+            marginTop: 20,
+            fontFamily: "NotoSansKR-Regular, sans-serif",
+            fontWeight: 400,
+          }}
+        >
+          한번 삭제된 공간과 리스트는 복구할 수 없습니다.
+        </div>
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <button
+          className="modal-next"
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            width: "30%",
+            height: "20%",
+            background: "#8be2b6",
+            color: "#fff",
+            border: "none",
+            borderRadius: 15,
+            padding: "10px 20px",
+            fontFamily: "NotoSansKR-Bold, sans-serif",
+            fontWeight: 700,
+            fontSize: "1rem",
+            cursor: "pointer",
+          }}
+          onClick={onConfirm}
+          onMouseEnter={(e) => {
+            e.target.style.background = "#74D3A4";
+          }}
+          onMouseLeave={(e) => {
+            e.target.style.background = "#8BE2B6";
+          }}
+        >
+          삭제
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+export default DeleteModal;

--- a/src/components/CreateSpaceModal/Step1Modal.jsx
+++ b/src/components/CreateSpaceModal/Step1Modal.jsx
@@ -9,6 +9,7 @@ function Step1Modal({
   onNext,
   isOpen,
   onClose,
+  isDuplicate,
 }) {
   return (
     <Modal
@@ -124,7 +125,24 @@ function Step1Modal({
         />
       </div>
 
-      <button className="modal-next" onClick={onNext} disabled={!spaceName}>
+      {isDuplicate && spaceName && (
+        <div
+          style={{
+            color: "red",
+            fontSize: "0.85rem",
+            marginTop: 10,
+            textAlign: "center",
+          }}
+        >
+          이미 존재하는 공간명입니다
+        </div>
+      )}
+
+      <button
+        className="modal-next"
+        onClick={onNext}
+        disabled={!spaceName || isDuplicate}
+      >
         다음
       </button>
     </Modal>

--- a/src/components/CreateSpaceModal/Step1Modal.jsx
+++ b/src/components/CreateSpaceModal/Step1Modal.jsx
@@ -16,8 +16,8 @@ function Step1Modal({
       onClose={onClose}
       contentStyle={{
         width: "400px",
-        maxWidth: "none", // 최대 너비 제한 해제
-        minWidth: "auto", // 최소 너비 제거
+        maxWidth: "none",
+        minWidth: "auto",
       }}
     >
       <div

--- a/src/components/CreateSpaceModal/Step2Modal.jsx
+++ b/src/components/CreateSpaceModal/Step2Modal.jsx
@@ -14,7 +14,7 @@ function Step2Modal({
   placedShapes,
   editingShapeId,
 }) {
-  // ✅ 10x10 그리드 기반 배치 가능성 검사 함수
+  // 10x10 그리드 기반 배치 가능성 검사 함수
   const canPlaceAnywhere = (w, h) => {
     const grid = Array.from({ length: 10 }, () => Array(10).fill(false));
     for (const shape of placedShapes) {
@@ -45,7 +45,7 @@ function Step2Modal({
     return false;
   };
 
-  // ✅ 현재 선택된 방향과 사이즈로 배치 가능한지 검사
+  // 현재 선택된 방향과 사이즈로 배치 가능한지 검사
   const baseW = modalShape?.w ?? 1;
   const baseH = modalShape?.h ?? 1;
 

--- a/src/components/CreateSpaceModal/Step2Modal.jsx
+++ b/src/components/CreateSpaceModal/Step2Modal.jsx
@@ -18,8 +18,8 @@ function Step2Modal({
       onClose={onClose}
       contentStyle={{
         width: "400px",
-        maxWidth: "none", // 최대 너비 제한 해제
-        minWidth: "auto", // 최소 너비 제거
+        maxWidth: "none",
+        minWidth: "auto",
       }}
     >
       <button className="modal-back" onClick={onBack}>

--- a/src/components/CreateSpaceModal/Step2Modal.jsx
+++ b/src/components/CreateSpaceModal/Step2Modal.jsx
@@ -11,7 +11,51 @@ function Step2Modal({
   onBack,
   isOpen,
   onClose,
+  placedShapes,
+  editingShapeId,
 }) {
+  // ✅ 10x10 그리드 기반 배치 가능성 검사 함수
+  const canPlaceAnywhere = (w, h) => {
+    const grid = Array.from({ length: 10 }, () => Array(10).fill(false));
+    for (const shape of placedShapes) {
+      if (shape.space_id === editingShapeId) continue;
+
+      for (let r = shape.top; r < shape.top + shape.h; r++) {
+        for (let c = shape.left; c < shape.left + shape.w; c++) {
+          grid[r][c] = true;
+        }
+      }
+    }
+
+    for (let row = 0; row <= 10 - h; row++) {
+      for (let col = 0; col <= 10 - w; col++) {
+        let canPlace = true;
+        for (let r = 0; r < h; r++) {
+          for (let c = 0; c < w; c++) {
+            if (grid[row + r][col + c]) {
+              canPlace = false;
+              break;
+            }
+          }
+          if (!canPlace) break;
+        }
+        if (canPlace) return true;
+      }
+    }
+    return false;
+  };
+
+  // ✅ 현재 선택된 방향과 사이즈로 배치 가능한지 검사
+  const baseW = modalShape?.w ?? 1;
+  const baseH = modalShape?.h ?? 1;
+
+  const targetW =
+    shapeDirection === "horizontal" ? baseW * shapeSize : baseH * shapeSize;
+  const targetH =
+    shapeDirection === "horizontal" ? baseH * shapeSize : baseW * shapeSize;
+
+  const isPlaceable = canPlaceAnywhere(targetW, targetH);
+
   return (
     <Modal
       isOpen={isOpen}
@@ -145,7 +189,20 @@ function Step2Modal({
         </div>
       </div>
 
-      <button className="modal-next" onClick={onNext}>
+      {!isPlaceable && (
+        <div
+          style={{
+            color: "red",
+            fontSize: "0.85rem",
+            marginTop: 10,
+            textAlign: "center",
+          }}
+        >
+          현재 그리드에 배치할 공간이 없어요.
+        </div>
+      )}
+
+      <button className="modal-next" onClick={onNext} disabled={!isPlaceable}>
         다음
       </button>
     </Modal>

--- a/src/components/CreateSpaceModal/Step2Modal.jsx
+++ b/src/components/CreateSpaceModal/Step2Modal.jsx
@@ -92,8 +92,8 @@ function Step2Modal({
         >
           <input
             type="radio"
-            checked={shapeDirection === "vertical"}
-            onChange={() => setShapeDirection("vertical")}
+            checked={shapeDirection === "horizontal"}
+            onChange={() => setShapeDirection("horizontal")}
           />
           <span>가로</span>
         </label>
@@ -110,8 +110,8 @@ function Step2Modal({
         >
           <input
             type="radio"
-            checked={shapeDirection === "horizontal"}
-            onChange={() => setShapeDirection("horizontal")}
+            checked={shapeDirection === "vertical"}
+            onChange={() => setShapeDirection("vertical")}
           />
           <span>세로</span>
         </label>

--- a/src/components/CreateSpaceModal/Step2Modal.jsx
+++ b/src/components/CreateSpaceModal/Step2Modal.jsx
@@ -198,7 +198,7 @@ function Step2Modal({
             textAlign: "center",
           }}
         >
-          현재 그리드에 배치할 공간이 없어요.
+          현재 그리드에 배치할 공간이 없어요
         </div>
       )}
 

--- a/src/components/CreateSpaceModal/Step2Modal.jsx
+++ b/src/components/CreateSpaceModal/Step2Modal.jsx
@@ -41,8 +41,8 @@ function Step2Modal({
       <div
         className="modal-shape-preview"
         style={{
-          width: 50 * modalShape.w,
-          height: 50 * modalShape.h,
+          width: `${50 * (modalShape?.w ?? 1)}px`,
+          height: `${50 * (modalShape?.h ?? 1)}px`,
           margin: "5px auto 20px",
           background: "#EBFEF4",
           border: "2px solid #8BE2B6",

--- a/src/components/CreateSpaceModal/Step3Modal.jsx
+++ b/src/components/CreateSpaceModal/Step3Modal.jsx
@@ -3,39 +3,10 @@ import "./CreateModal.css";
 
 function Step3Modal({ previewShape, onNext, onBack, isOpen, onClose }) {
   if (!previewShape) return null;
-  // // 방향에 따라 w, h 결정
-  // let w = modalShape.w;
-  // let h = modalShape.h;
-  // if (shapeDirection === "vertical") {
-  //   w = modalShape.h;
-  //   h = modalShape.w;
-  // }
-
-  // const handlePreviewAndNext = () => {
-  //   const previewShape = {
-  //     ...modalShape,
-  //     w: w * shapeSize,
-  //     h: h * shapeSize,
-  //     name: spaceName,
-  //     type: 0,
-  //     direction: shapeDirection,
-  //   };
-  //   setPreviewShape(previewShape);
-  //   onNext();
-  // };
 
   const { w, h, name, ratioW, ratioH } = previewShape;
-
   const previewWidth = 70 * w;
   const previewHeight = 70 * h;
-
-  // const handlePreviewAndNext = () => {
-  //   setPreviewShape(pendingShape); // preview 상태 저장
-  //   onNext(); // 다음 단계로 진행 (도형 배치 준비 완료)
-  // };
-
-  // const ratioW = w * shapeSize;
-  // const ratioH = h * shapeSize;
 
   return (
     <Modal

--- a/src/components/CreateSpaceModal/Step3Modal.jsx
+++ b/src/components/CreateSpaceModal/Step3Modal.jsx
@@ -1,46 +1,41 @@
 import Modal from "../Modal";
 import "./CreateModal.css";
 
-function Step3Modal({
-  modalShape,
-  shapeDirection,
-  spaceName,
-  shapeSize,
-  onNext,
-  onBack,
-  setPreviewShape,
-  isOpen,
-  onClose,
-}) {
-  // 방향에 따라 w, h 결정
-  let w = modalShape.w;
-  let h = modalShape.h;
-  if (shapeDirection === "vertical") {
-    w = modalShape.h;
-    h = modalShape.w;
-  }
+function Step3Modal({ previewShape, onNext, onBack, isOpen, onClose }) {
+  if (!previewShape) return null;
+  // // 방향에 따라 w, h 결정
+  // let w = modalShape.w;
+  // let h = modalShape.h;
+  // if (shapeDirection === "vertical") {
+  //   w = modalShape.h;
+  //   h = modalShape.w;
+  // }
 
-  const handlePreviewAndNext = () => {
-    const previewShape = {
-      ...modalShape,
-      w: w * shapeSize,
-      h: h * shapeSize,
-      name: spaceName,
-      type: 0,
-      direction: shapeDirection,
-    };
-    setPreviewShape(previewShape);
-    onNext();
-  };
+  // const handlePreviewAndNext = () => {
+  //   const previewShape = {
+  //     ...modalShape,
+  //     w: w * shapeSize,
+  //     h: h * shapeSize,
+  //     name: spaceName,
+  //     type: 0,
+  //     direction: shapeDirection,
+  //   };
+  //   setPreviewShape(previewShape);
+  //   onNext();
+  // };
 
-  // 미리보기 도형 style 계산
-  const baseWidth = 70 * w;
-  const baseHeight = 70 * h;
-  const previewWidth = baseWidth;
-  const previewHeight = baseHeight;
+  const { w, h, name, ratioW, ratioH } = previewShape;
 
-  const ratioW = w * shapeSize;
-  const ratioH = h * shapeSize;
+  const previewWidth = 70 * w;
+  const previewHeight = 70 * h;
+
+  // const handlePreviewAndNext = () => {
+  //   setPreviewShape(pendingShape); // preview 상태 저장
+  //   onNext(); // 다음 단계로 진행 (도형 배치 준비 완료)
+  // };
+
+  // const ratioW = w * shapeSize;
+  // const ratioH = h * shapeSize;
 
   return (
     <Modal
@@ -48,8 +43,8 @@ function Step3Modal({
       onClose={onClose}
       contentStyle={{
         width: "400px",
-        maxWidth: "none", // 최대 너비 제한 해제
-        minWidth: "auto", // 최소 너비 제거
+        maxWidth: "none",
+        minWidth: "auto",
       }}
     >
       <button className="modal-back" onClick={onBack}>
@@ -100,13 +95,13 @@ function Step3Modal({
           position: "relative",
         }}
       >
-        {spaceName}
+        {name}
         <span className="shape-ratio">
           {ratioW}x{ratioH}
         </span>
       </div>
 
-      <button className="modal-next" onClick={handlePreviewAndNext}>
+      <button className="modal-next" onClick={onNext}>
         다음
       </button>
     </Modal>

--- a/src/components/CreateSpaceModal/Step3Modal.jsx
+++ b/src/components/CreateSpaceModal/Step3Modal.jsx
@@ -15,7 +15,7 @@ function Step3Modal({
   // 방향에 따라 w, h 결정
   let w = modalShape.w;
   let h = modalShape.h;
-  if (shapeDirection === "horizontal") {
+  if (shapeDirection === "vertical") {
     w = modalShape.h;
     h = modalShape.w;
   }

--- a/src/pages/CreatePages/CreateSpacePage.css
+++ b/src/pages/CreatePages/CreateSpacePage.css
@@ -95,8 +95,8 @@ body {
   position: absolute;
   top: 0;
   left: 0;
-  background: #8be2b6;
   border-radius: 5px;
+  border: 0.1px solid #e5e2e2;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/CreatePages/CreateSpacePage.css
+++ b/src/pages/CreatePages/CreateSpacePage.css
@@ -117,7 +117,8 @@ body {
   border: none;
 }
 
-.trash-icon {
+.trash-icon,
+.pencil-icon {
   pointer-events: auto;
 }
 

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -35,8 +35,6 @@ const SHAPE_COLORS = [
   "#3ACF85",
   "#30C57A",
   "#2CB570",
-  "#28A466",
-  "#24945C",
 ];
 
 const formatForBackend = (shape) => {

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -70,7 +70,7 @@ function CreateSpacePage() {
   const [modalShape, setModalShape] = useState(null); // 선택된 도형 정보
   const [spaceType, setSpaceType] = useState(0);
   const [spaceName, setSpaceName] = useState("");
-  const [shapeDirection, setShapeDirection] = useState("vertical");
+  const [shapeDirection, setShapeDirection] = useState("horizontal");
   const [shapeSize, setShapeSize] = useState(1); // 도형 크기
   const [pendingShape, setPendingShape] = useState(null); // 실제 배치할 shape
   const [hoverCell, setHoverCell] = useState(null); // 그리드 패널 - 미리보기
@@ -90,7 +90,7 @@ function CreateSpacePage() {
     setModalStep(1);
     setSpaceType(0);
     setSpaceName("");
-    setShapeDirection("vertical");
+    setShapeDirection("horizontal");
     setShapeSize(1);
     setPendingShape(null);
   };
@@ -108,7 +108,7 @@ function CreateSpacePage() {
     let w = modalShape.w,
       h = modalShape.h;
 
-    if (shapeDirection === "horizontal") {
+    if (shapeDirection === "vertical") {
       w = modalShape.h;
       h = modalShape.w;
     }
@@ -128,7 +128,7 @@ function CreateSpacePage() {
     // 방향에 따라 w, h 결정
     let w = modalShape.w;
     let h = modalShape.h;
-    if (shapeDirection === "horizontal") {
+    if (shapeDirection === "vertical") {
       w = modalShape.h;
       h = modalShape.w;
     }
@@ -474,9 +474,9 @@ function CreateSpacePage() {
   );
 }
 
-function ShapeButton({ shape, onClick, direction = "vertical" }) {
-  const w = direction === "horizontal" ? shape.h : shape.w;
-  const h = direction === "horizontal" ? shape.w : shape.h;
+function ShapeButton({ shape, onClick, direction = "horizontal" }) {
+  const w = direction === "vertical" ? shape.h : shape.w;
+  const h = direction === "vertical" ? shape.w : shape.h;
   return (
     <button
       className="shape-btn"

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -220,6 +220,15 @@ function CreateSpacePage() {
     setShouldReplaceShapeId(null);
   };
 
+  // 중복 공간명 제한
+  const isDuplicateSpaceName = (name) => {
+    // 편집 모드일 때는 현재 편집 중인 도형은 제외
+    const shapesToCheck = placedShapes.filter(
+      (shape) => shape.space_id !== editingShapeId
+    );
+    return shapesToCheck.some((shape) => shape.name === name);
+  };
+
   // step1: 공간 종류 선택 / 공간 이름 입력
   const handleStep1 = () => {
     if (!spaceName) return;
@@ -301,6 +310,7 @@ function CreateSpacePage() {
           spaceName={spaceName}
           setSpaceName={setSpaceName}
           onNext={handleStep1}
+          isDuplicate={isDuplicateSpaceName(spaceName)}
         />
       );
     }

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -57,11 +57,11 @@ const parseFromBackend = (spaceData) => {
   // direction에 따라 기본 크기 계산
   let baseW, baseH;
   if (spaceData.direction === "vertical") {
-    baseW = spaceData.height / spaceData.size; // 실제 세로를 기본 가로로
-    baseH = spaceData.width / spaceData.size; // 실제 가로를 기본 세로로
+    baseW = spaceData.height / spaceData.size;
+    baseH = spaceData.width / spaceData.size;
   } else {
-    baseW = spaceData.width / spaceData.size; // 실제 가로를 기본 가로로
-    baseH = spaceData.height / spaceData.size; // 실제 세로를 기본 세로로
+    baseW = spaceData.width / spaceData.size;
+    baseH = spaceData.height / spaceData.size;
   }
 
   return {
@@ -78,8 +78,8 @@ const parseFromBackend = (spaceData) => {
     direction: spaceData.direction,
     shapeSize: spaceData.size,
     color: SHAPE_COLORS[Math.floor(Math.random() * SHAPE_COLORS.length)],
-    originalW: baseW, // 기본 크기 저장
-    originalH: baseH, // 기본 크기 저장
+    originalW: baseW,
+    originalH: baseH,
   };
 };
 
@@ -263,7 +263,7 @@ function CreateSpacePage() {
   // step3: 위치 선택 안내
   const handleStep3 = () => {
     if (editingShapeId !== null) {
-      setShouldReplaceShapeId(editingShapeId); // 교체 시작
+      setShouldReplaceShapeId(editingShapeId);
     }
     setModalStep(0);
     setModalShape(null);
@@ -624,18 +624,12 @@ function CreateSpacePage() {
                               setShapeDirection(placedShape.direction);
                               setShapeSize(placedShape.shapeSize);
 
-                              // [NEW] 올바른 도형을 SHAPES에서 찾아 modalShape으로 세팅
+                              // 올바른 도형을 SHAPES에서 찾아 modalShape으로 세팅
                               const baseShape = SHAPES.find(
                                 (s) =>
-                                  s.w === placedShape.originalW && // baseW 대신 w 사용
-                                  s.h === placedShape.originalH // baseH 대신 h 사용
+                                  s.w === placedShape.originalW &&
+                                  s.h === placedShape.originalH
                               );
-                              //   (s) =>
-                              //     s.baseW === placedShape.originalW &&
-                              //     s.baseH === placedShape.originalH
-                              // );
-
-                              // setModalShape(baseShape); // 항상 base 형태로 넘겨줌
 
                               if (baseShape) {
                                 setModalShape(baseShape);
@@ -646,18 +640,6 @@ function CreateSpacePage() {
                                   h: placedShape.originalH,
                                 });
                               }
-
-                              // // 미리보기에 direction 반영
-                              // const isVertical =
-                              //   placedShape.direction === "vertical";
-                              // setModalShape({
-                              //   w: isVertical
-                              //     ? placedShape.originalH
-                              //     : placedShape.originalW,
-                              //   h: isVertical
-                              //     ? placedShape.originalW
-                              //     : placedShape.originalH,
-                              // });
 
                               // 상태 초기화
                               setPendingShape(null);

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -77,7 +77,7 @@ const parseFromBackend = (spaceData) => {
     h: spaceData.height,
     direction: spaceData.direction,
     shapeSize: spaceData.size,
-    color: SHAPE_COLORS[spaceData.space_id % SHAPE_COLORS.length],
+    color: SHAPE_COLORS[Math.floor(Math.random() * SHAPE_COLORS.length)],
     originalW: baseW, // 기본 크기 저장
     originalH: baseH, // 기본 크기 저장
   };
@@ -531,7 +531,11 @@ function CreateSpacePage() {
                               console.log("[디버깅] 배치 실행됨");
                               // 색상 할당
                               const color =
-                                SHAPE_COLORS[colorIndex % SHAPE_COLORS.length];
+                                SHAPE_COLORS[
+                                  Math.floor(
+                                    Math.random() * SHAPE_COLORS.length
+                                  )
+                                ];
 
                               // ✅ 1. 수정 모드 여부 판단
                               const isEditing =

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -479,19 +479,6 @@ function CreateSpacePage() {
                             ? shouldReplaceShapeId
                             : nextSpaceId;
 
-                          console.log("[디버깅] isEditing:", isEditing);
-                          console.log(
-                            "[디버깅] assignedSpaceId:",
-                            assignedSpaceId
-                          );
-                          console.log(
-                            "[디버깅] shouldReplaceShapeId:",
-                            shouldReplaceShapeId
-                          );
-                          console.log(
-                            "[디버깅] editingShapeId:",
-                            editingShapeId
-                          );
                           // 그리드 밖으로 나가는지 체크
                           const { w, h } = pendingShape;
                           if (
@@ -526,9 +513,8 @@ function CreateSpacePage() {
                               }
                               if (overlap) break;
                             }
-                            console.log("[디버깅] overlap 상태:", overlap);
+
                             if (!overlap) {
-                              console.log("[디버깅] 배치 실행됨");
                               // 색상 할당
                               const color =
                                 SHAPE_COLORS[

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -87,7 +87,6 @@ function CreateSpacePage() {
 
   useEffect(() => {
     if (modalStep === 3 && pendingShape) {
-      console.log("[useEffect] Step3 진입. pendingShape:", pendingShape);
       const { w, h, name } = pendingShape;
 
       const previewShape = {
@@ -104,7 +103,6 @@ function CreateSpacePage() {
 
   // 도형 버튼 클릭 시
   const handleShapeSelect = (shape) => {
-    console.log("[handleShapeSelect] 도형 선택됨:", shape);
     setModalShape(shape);
     setModalStep(1);
     setSpaceType(0);
@@ -116,7 +114,6 @@ function CreateSpacePage() {
 
   // step1: 공간 종류 선택 / 공간 이름 입력
   const handleStep1 = () => {
-    console.log("[handleStep1] 공간 이름:", spaceName);
     if (!spaceName) return;
     setModalStep(2);
   };
@@ -146,8 +143,6 @@ function CreateSpacePage() {
       originalW: modalShape.w,
       originalH: modalShape.h,
     };
-
-    console.log("[handleStep2] pendingShape 설정:", newPending);
 
     setPendingShape(newPending);
     setModalStep(3);
@@ -338,23 +333,6 @@ function CreateSpacePage() {
                         if (pendingShape) setHoverCell(null);
                       }}
                       onClick={() => {
-                        console.log("[그리드 셀 클릭] hoverCell:", hoverCell);
-                        console.log(
-                          "[그리드 셀 클릭] pendingShape:",
-                          pendingShape
-                        );
-
-                        console.log(
-                          "[클릭 시점] pendingShape.w/h:",
-                          pendingShape?.w,
-                          pendingShape?.h
-                        );
-                        console.log(
-                          "[클릭 시점] hoverCell 위치:",
-                          hoverCell?.row,
-                          hoverCell?.col
-                        );
-
                         if (
                           !pendingShape ||
                           !hoverCell ||
@@ -428,13 +406,6 @@ function CreateSpacePage() {
                                 originalH: pendingShape.originalH,
                                 shapeSize: shapeSize,
                               };
-
-                              console.log(
-                                `[도형 배치] ${
-                                  isEditing ? "수정됨" : "신규 생성됨"
-                                } - space_id:`,
-                                assignedSpaceId
-                              );
 
                               // ✅ 4. 도형 상태 업데이트
                               if (isEditing) {

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -72,9 +72,9 @@ function CreateSpacePage() {
   const [spaceName, setSpaceName] = useState("");
   const [shapeDirection, setShapeDirection] = useState("horizontal");
   const [shapeSize, setShapeSize] = useState(1); // 도형 크기
-  const [pendingShape, setPendingShape] = useState(null); // 실제 배치할 shape
+  const [pendingShape, setPendingShape] = useState(null); // 실제 배치할 shape (modal3 종료 후)
   const [hoverCell, setHoverCell] = useState(null); // 그리드 패널 - 미리보기
-  const [previewShape, setPreviewShape] = useState(null);
+  const [previewShape, setPreviewShape] = useState(null); // modal3에서 사용
 
   const navigate = useNavigate();
 
@@ -83,9 +83,9 @@ function CreateSpacePage() {
       const { w, h, name } = pendingShape;
 
       const previewShape = {
-        w: Math.max(1, w / shapeSize), // 화면 표시용: 축소
-        h: Math.max(1, h / shapeSize), // 화면 표시용: 축소
-        ratioW: w, // 실제 크기 (텍스트 표시용)
+        w: Math.max(1, w / shapeSize),
+        h: Math.max(1, h / shapeSize),
+        ratioW: w,
         ratioH: h,
         name,
       };
@@ -93,12 +93,6 @@ function CreateSpacePage() {
       setPreviewShape(previewShape);
     }
   }, [modalStep, pendingShape, shapeSize]);
-
-  // useEffect(() => {
-  //   if (!pendingShape) {
-  //     setHoverCell(null);
-  //   }
-  // }, [pendingShape]);
 
   // 도형 버튼 클릭 시
   const handleShapeSelect = (shape) => {
@@ -196,8 +190,6 @@ function CreateSpacePage() {
           isOpen={!!modalStep}
           onClose={handleClose}
           previewShape={previewShape}
-          // pendingShape={pendingShape}
-          // setPreviewShape={setPreviewShape}
           onNext={handleStep3}
           onBack={handleBack}
         />

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -3,7 +3,8 @@ import Header from "../../components/Header";
 import Step1Modal from "../../components/CreateSpaceModal/Step1Modal";
 import Step2Modal from "../../components/CreateSpaceModal/Step2Modal";
 import Step3Modal from "../../components/CreateSpaceModal/Step3Modal";
-import { FaTrashAlt } from "react-icons/fa";
+import DeleteModal from "../../components/CreateSpaceModal/DeleteModal";
+import { FaTrashAlt, FaPencilAlt } from "react-icons/fa";
 import "./CreateSpacePage.css";
 import { useNavigate } from "react-router-dom";
 
@@ -75,6 +76,9 @@ function CreateSpacePage() {
   const [pendingShape, setPendingShape] = useState(null); // 실제 배치할 shape (modal3 종료 후)
   const [hoverCell, setHoverCell] = useState(null); // 그리드 패널 - 미리보기
   const [previewShape, setPreviewShape] = useState(null); // modal3에서 사용
+
+  const [deleteShapeId, setDeleteShapeId] = useState(null); // 삭제할 shape_id
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const navigate = useNavigate();
 
@@ -198,6 +202,23 @@ function CreateSpacePage() {
 
     return null;
   };
+
+  const renderDeleteModal = () => (
+    <DeleteModal
+      isOpen={showDeleteModal}
+      onClose={() => setShowDeleteModal(false)}
+      onConfirm={() => {
+        setPlacedShapes((prev) =>
+          prev.filter((shape) => shape.space_id !== deleteShapeId)
+        );
+        setShowDeleteModal(false);
+        setDeleteShapeId(null);
+      }}
+      spaceName={
+        placedShapes.find((s) => s.space_id === deleteShapeId)?.name || ""
+      }
+    />
+  );
 
   return (
     <>
@@ -381,8 +402,8 @@ function CreateSpacePage() {
                           }}
                         >
                           {placedShape.name}
-                          <FaTrashAlt
-                            className="trash-icon"
+                          <FaPencilAlt
+                            className="pencil-icon"
                             style={{
                               position: "absolute",
                               top: "6px",
@@ -393,15 +414,31 @@ function CreateSpacePage() {
                               cursor: "pointer",
                               zIndex: 3,
                             }}
+                          />
+
+                          <FaTrashAlt
+                            className="trash-icon"
+                            style={{
+                              position: "absolute",
+                              bottom: "6px",
+                              right: "6px",
+                              width: "15px",
+                              height: "15px",
+                              color: "#1a1a1a",
+                              cursor: "pointer",
+                              zIndex: 3,
+                            }}
                             onClick={(e) => {
                               e.stopPropagation();
+                              setDeleteShapeId(placedShape.space_id);
+                              setShowDeleteModal(true);
 
-                              setPlacedShapes((prevShapes) =>
-                                prevShapes.filter(
-                                  (shape) =>
-                                    shape.space_id !== placedShape.space_id
-                                )
-                              );
+                              // setPlacedShapes((prevShapes) =>
+                              //   prevShapes.filter(
+                              //     (shape) =>
+                              //       shape.space_id !== placedShape.space_id
+                              //   )
+                              // );
                             }}
                           />
                         </div>
@@ -459,6 +496,7 @@ function CreateSpacePage() {
           </div>
         </div>
         {renderModal()}
+        {renderDeleteModal()}
       </div>
     </>
   );

--- a/src/pages/CreatePages/CreateSpacePage.jsx
+++ b/src/pages/CreatePages/CreateSpacePage.jsx
@@ -79,10 +79,26 @@ function CreateSpacePage() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!pendingShape) {
-      setHoverCell(null);
+    if (modalStep === 3 && pendingShape) {
+      const { w, h, name } = pendingShape;
+
+      const previewShape = {
+        w: Math.max(1, w / shapeSize), // 화면 표시용: 축소
+        h: Math.max(1, h / shapeSize), // 화면 표시용: 축소
+        ratioW: w, // 실제 크기 (텍스트 표시용)
+        ratioH: h,
+        name,
+      };
+
+      setPreviewShape(previewShape);
     }
-  }, [pendingShape]);
+  }, [modalStep, pendingShape, shapeSize]);
+
+  // useEffect(() => {
+  //   if (!pendingShape) {
+  //     setHoverCell(null);
+  //   }
+  // }, [pendingShape]);
 
   // 도형 버튼 클릭 시
   const handleShapeSelect = (shape) => {
@@ -103,36 +119,15 @@ function CreateSpacePage() {
 
   // step2: 도형 방향 / 크기 선택
   const handleStep2 = () => {
-    setModalStep(3);
-
-    let w = modalShape.w,
-      h = modalShape.h;
-
-    if (shapeDirection === "vertical") {
-      w = modalShape.h;
-      h = modalShape.w;
-    }
-
-    setPendingShape({
-      ...modalShape,
-      w: w * shapeSize,
-      h: h * shapeSize,
-      name: spaceName,
-      type: spaceType,
-      direction: shapeDirection,
-    });
-  };
-
-  // step3: 위치 선택 안내
-  const handleStep3 = () => {
-    // 방향에 따라 w, h 결정
     let w = modalShape.w;
     let h = modalShape.h;
+
     if (shapeDirection === "vertical") {
       w = modalShape.h;
       h = modalShape.w;
     }
-    const newPendingShape = {
+
+    const newPending = {
       ...modalShape,
       w: w * shapeSize,
       h: h * shapeSize,
@@ -140,8 +135,13 @@ function CreateSpacePage() {
       type: spaceType,
       direction: shapeDirection,
     };
-    setPendingShape(newPendingShape);
 
+    setPendingShape(newPending);
+    setModalStep(3);
+  };
+
+  // step3: 위치 선택 안내
+  const handleStep3 = () => {
     setModalStep(0);
     setModalShape(null);
   };
@@ -195,11 +195,9 @@ function CreateSpacePage() {
         <Step3Modal
           isOpen={!!modalStep}
           onClose={handleClose}
-          modalShape={modalShape}
-          shapeDirection={shapeDirection}
-          spaceName={spaceName}
-          shapeSize={shapeSize}
-          setPreviewShape={setPreviewShape}
+          previewShape={previewShape}
+          // pendingShape={pendingShape}
+          // setPreviewShape={setPreviewShape}
           onNext={handleStep3}
           onBack={handleBack}
         />


### PR DESCRIPTION
## 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🌿 반영 브랜치
> main <- feature/18-editSpace

## 💻 작업 내용
> 1. Space 의 상태 관리 (State) 로직 정리 
> 2. Delete 모달창 구현 
> 3. Edit 모달창 및 공간 편집 기능 구현

## 🔑 주요 변경사항
> 1. Space 의 상태 관리 (State) 로직 정리 
           ㄴ CreateSpacePage 에서 모든 도형 상태 관리 
> 2. Delete 모달창 구현 
           ㄴ space_id 기준 삭제, 상태 반영 
> 3. Edit 모달창 및 공간 편집 기능 구현
           ㄴ (step1) 공간명 중복 제한 기능 구현 
           ㄴ (step2) 그리드 배치 가능 여부 판단 기능 구현 
           ㄴ 편집 모드 진입 시, 기존 도형 정보 복원 로직 강화 
           ㄴ 모달 단계별 상태 초기화 로직 강화 
           ㄴ 여러 번 편집 시의 상태 불일치 현상 개선 

## ✅ 테스트 결과 (이미지 또는 영상 첨부)
- [x] 기능 동작 확인 완료
- [x] 콘솔 경고 없음

https://github.com/user-attachments/assets/e9fbba0c-29a5-47e9-92c2-d26f1f1f90b5

## 💬 리뷰 요청사항 또는 개인 코멘트
> 초기 데이터의 방향이 무엇인지 / edit 를 몇 번 시도했는지 / 어느 시점에 edit 모달창을 나가는지 등 여러 상황에 따라 발생했던 오류가 많습니다. 최대한 다 잡았으나, 놓친 오류가 있을 수 있으니 테스트하시어 검토 부탁드립니다. 
